### PR TITLE
Override FetchContent flag to make sure that content is populated

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
 		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
+                -DFETCHCONTENT_FULLY_DISCONNECTED=OFF \
 		$(BUILD_TESTING_ARG)
 
 override_dh_auto_build:


### PR DESCRIPTION
This PR is imported from https://github.com/Fields2Cover/fields2cover-release/pull/1

The changes were made by @aosmw